### PR TITLE
GET aws access key through command line

### DIFF
--- a/lib/deployer.js
+++ b/lib/deployer.js
@@ -3,6 +3,7 @@ var level = require('level');
 var s3sync = require('s3-sync-aws');
 var readdirp = require('readdirp');
 var cloudfront = require('cloudfront');
+var child_process = require('child_process');
 
 module.exports = function(args) {
   var publicDir = this.config.public_dir;
@@ -13,11 +14,11 @@ module.exports = function(args) {
   }
 
   if (!args.hasOwnProperty('aws_key')) {
-    args.aws_key = process.env.AWS_KEY;
+    args.aws_key = child_process.execSync('aws configure get aws_access_key_id').toString().replace('\n','')
   }
 
   if (!args.hasOwnProperty('aws_secret')) {
-    args.aws_secret = process.env.AWS_SECRET;
+    args.aws_secret = child_process.execSync('aws configure get aws_secret_access_key').toString().replace('\n','')
   }
 
   if (!args.hasOwnProperty('force_overwrite')) {
@@ -26,10 +27,6 @@ module.exports = function(args) {
 
   if (!args.hasOwnProperty('headers')) {
     args.headers = {};
-  }
-
-  if (!args.hasOwnProperty('prefix')) {
-    args.prefix = false;
   }
 
   if (!args.bucket || !args.aws_key || !args.aws_secret) {
@@ -45,8 +42,7 @@ module.exports = function(args) {
     help += '    [concurrency]: <concurrency> # Optional\n';
     help += '    [force_overwrite]: <true/false>   # Optional, default true\n';
     help += '    [region]: <region>          # Optional, default "us-standard"\n';
-    help += '    [prefix]: <S3 key prefix ending in /> # Optional\n';
-    help += '    [cf_distribution]: <cf_distribution> # Optional\n';
+    help += '    [cf_distribution]: <cf_distribution> # Optional,\n';
     help += '    [headers]: <headers in json format> # Optional\n\n';
     help += 'For more help, you can check the docs: ' + chalk.underline('https://github.com/Wouter33/hexo-deployer-s3-cloudfront');
 
@@ -72,9 +68,6 @@ module.exports = function(args) {
   if(args.force_overwrite){
       syncinput.force = true;
   }
-  if(args.prefix){
-      syncinput.prefix = args.prefix;
-  }
 
   return readdirp({root: publicDir, entryType: 'both'})
       .pipe(s3sync(db, syncinput).on('data', function(file) {
@@ -88,9 +81,7 @@ module.exports = function(args) {
 
             var cf = cloudfront.createClient(args.aws_key, args.aws_secret);
 
-            var cfPath = '/' + args.prefix + '*' || '/*';
-
-            return cf.createInvalidation(args.cf_distribution, 'dsadasds' + Math.round(new Date().getTime()/1000), cfPath, function(err, invalidation) {
+            return cf.createInvalidation(args.cf_distribution, 'dsadasds' + Math.round(new Date().getTime()/1000), '/*', function(err, invalidation) {
                 if (err){
                     console.log(err);
                 } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "hexo-deployer-s3-cloudfront",
+  "version": "0.1.4",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "child_process": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/child_process/-/child_process-1.0.2.tgz",
+      "integrity": "sha1-sffn/HPSXn/R1FWtyU4UODAYK1o="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -40,10 +40,11 @@
   },
   "dependencies": {
     "chalk": "^1.0.0",
+    "child_process": "^1.0.2",
+    "cloudfront": "^0.3.3",
     "level": "^1.4.0",
     "readdirp": "^0.3.3",
-    "s3-sync-aws": "^1.1.0",
-    "cloudfront": "^0.3.3"
+    "s3-sync-aws": "^1.1.0"
   },
   "readme": "# hexo-deployer-s3-cloudfront\n\nAmazon S3 and Cloudfront deployer plugin for [Hexo](http://hexo.io/). Based on Josh Strange's orginial plugin.\n\n## Installation\n\n``` bash\n$ npm install hexo-deployer-s3-cloudfront --save\n```\n\n## Usage\n\nAdd the plugin in the plugins list in `_config.yml`:\n\n```plugins:\n- hexo-deployer-s3-cloudfront\n```\n\nand configure the plugin in the same file with:\n\n``` yaml\n# You can use this:\ndeploy:\n  type: s3-cloudfront\n  bucket: <S3 bucket>\n  aws_key: <AWS id key>  // Optional, if the environment variable `AWS_KEY` is set\n  aws_secret: <AWS secret key>  // Optional, if the environment variable `AWS_SECRET` is set\n  concurrency: <number of connections> // Optional\n  region: <region>  // Optional, default: us-standard\n  cf_distribution: <cloudfront distribution> // Which distribution should be invalidated?\n```\n\n## Contributors\n\n- Wouter van Lent ([wouter33](https://github.com/wouter33))\n- Josh Strange ([joshstrange](https://github.com/joshstrange); original implementation)\n\n## License\n\nMIT\n",
   "readmeFilename": "README.md",


### PR DESCRIPTION
Some users have multiple accounts to manage on aws, it is not practical
for them to setup AWS_KEY and AWS_SECRET environment variable
everytime they switch accounts. Thus this commit simply executes
aws configure cli to get the crediential directly from aws cli